### PR TITLE
bugfix: h5py version is changed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ google-auth==2.22.0
 google-auth-oauthlib==1.0.0
 google-pasta==0.2.0
 grpcio==1.57.0
-h5py==3.9.0
+h5py==3.8.0
 idna==3.4
 importlib-metadata==6.8.0
 Jinja2==3.1.2


### PR DESCRIPTION
```
ERROR: Could not find a version that satisfies the requirement h5py==3.9.0 (from -r requirements.txt (line 21)) (from versions: 2.2.1, 2.3.0b1, 2.3.0, 2.3.1, 2.4.0b1, 2.4.0, 2.5.0, 2.6.0, 2.7.0rc2, 2.7.0, 2.7.1, 2.8.0rc1, 2.8.0, 2.9.0rc1, 2.9.0, 2.10.0, 3.0.0rc1, 3.0.0, 3.1.0, 3.2.0, 3.2.1, 3.3.0, 3.4.0, 3.5.0, 3.6.0, 3.7.0, 3.8.0)
Aug 27 04:44:19 PM  ERROR: No matching distribution found for h5py==3.9.0 (from -r requirements.txt (line 21))
```

So downgrade version